### PR TITLE
Add Total Commander key copying functionality

### DIFF
--- a/clean_install.ps1
+++ b/clean_install.ps1
@@ -150,7 +150,7 @@ function Copy-TotalCommanderKey {
     $destinationPath = "c:\Program Files\totalcmd\wincmd.key"
 
     Write-Host "Starting Google Drive. Please log in to your account." -ForegroundColor Cyan
-    Start-Process -FilePath "C:\Program Files\Google\Drive\launch.bat"
+    Start-Process -FilePath "c:\Program Files\Google\Drive File Stream\\launch.bat"
     Read-Host "Press Enter to continue..."
 
     if (Test-Path $sourcePath) {

--- a/clean_install.ps1
+++ b/clean_install.ps1
@@ -203,14 +203,14 @@ Install-Configure-GoogleDrive
 Install-Configure-VLC
 Install-Configure-VSCode
 Install-Configure-TotalCommander
-Copy-TotalCommanderKey
-
 Install-Configure-Git
 Install-Configure-GitExtensions
 Install-Configure-AutoHotkey
 
 Show-HiddenFilesAndFolders
 Show-FileExtensions
+
+Copy-TotalCommanderKey
 
 Write-Host "All applications installed and configured successfully!" -ForegroundColor Green
 

--- a/clean_install.ps1
+++ b/clean_install.ps1
@@ -150,7 +150,7 @@ function Copy-TotalCommanderKey {
     $destinationPath = "c:\Program Files\totalcmd\wincmd.key"
 
     Write-Host "Starting Google Drive. Please log in to your account." -ForegroundColor Cyan
-    Start-Process -FilePath "c:\Program Files\Google\Drive File Stream\\launch.bat"
+    Start-Process -FilePath "c:\Program Files\Google\Drive File Stream\launch.bat"
     Read-Host "Press Enter to continue..."
 
     if (Test-Path $sourcePath) {

--- a/clean_install.ps1
+++ b/clean_install.ps1
@@ -143,6 +143,24 @@ function Install-Configure-TotalCommander {
     choco install totalcommander -y --no-progress
 }
 
+# Function to copy Total Commander key
+function Copy-TotalCommanderKey {
+    Write-Host "Copying Total Commander key..." -ForegroundColor Yellow
+    $sourcePath = "g:\My Drive\TotalCommanderKey\wincmd.key"
+    $destinationPath = "c:\Program Files\totalcmd\wincmd.key"
+
+    Write-Host "Starting Google Drive. Please log in to your account." -ForegroundColor Cyan
+    Start-Process -FilePath "C:\Program Files\Google\Drive\launch.bat"
+    Read-Host "Press Enter to continue..."
+
+    if (Test-Path $sourcePath) {
+        Copy-Item -Path $sourcePath -Destination $destinationPath -Force
+        Write-Host "Total Commander key copied successfully." -ForegroundColor Green
+    } else {
+        Write-Host "Total Commander key not found at source path." -ForegroundColor Red
+    }
+}
+
 # Function to install and configure Git
 function Install-Configure-Git {
     Write-Host "Installing Git..." -ForegroundColor Yellow
@@ -185,6 +203,8 @@ Install-Configure-GoogleDrive
 Install-Configure-VLC
 Install-Configure-VSCode
 Install-Configure-TotalCommander
+Copy-TotalCommanderKey
+
 Install-Configure-Git
 Install-Configure-GitExtensions
 Install-Configure-AutoHotkey


### PR DESCRIPTION
Add functionality to copy Total Commander key after installation.

* Add `Copy-TotalCommanderKey` function to copy `wincmd.key` from `g:\My Drive\TotalCommanderKey\` to `c:\Program Files\totalcmd\`.
* Start Google Drive and prompt user to log in before copying the key.
* Replace `Start-Sleep -Seconds 10` with `Read-Host "Press Enter to continue..."` in `Install-Configure-qBittorrent`.
* Call `Copy-TotalCommanderKey` after `Install-Configure-TotalCommander` in the main script execution.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BalazsNagyNET/win_setup/pull/4?shareId=519e624d-0fc8-4444-9444-f58e3b8b9bf1).